### PR TITLE
Import high priority pa

### DIFF
--- a/db/migrate/20150616141402_add_high_priority_to_parcc_protected_areas.rb
+++ b/db/migrate/20150616141402_add_high_priority_to_parcc_protected_areas.rb
@@ -1,0 +1,9 @@
+class AddHighPriorityToParccProtectedAreas < ActiveRecord::Migration
+  def up
+    add_column :parcc_protected_areas, :high_priority, :boolean, default: false
+  end
+
+  def down
+    remove_column :parcc_protected_areas, :high_priority
+  end
+end

--- a/lib/data/parcc/high_priority_protected_areas.csv
+++ b/lib/data/parcc/high_priority_protected_areas.csv
@@ -94,7 +94,7 @@ Kassa,CIV,Classified Forest,0,1,1,2,2041-2070
 Kavi,CIV,Classified Forest,0,1,1,2,2041-2070
 Lakes of Ounianga,TCD,World Heritage Site,1,1,1,3,2041-2070
 Monogaga,CIV,Classified Forest,1,1,1,3,2041-2070
-Mount Nimba,CIV,National Reserve,1,1,1,3,2041-2070
+Mount Nimba,CIV,Integral National Reserve,1,1,1,3,2041-2070
 Mt. De,CIV,Classified Forest,1,1,1,3,2041-2070
 Ndokouassikro,CIV,Classified Forest,1,0,1,2,2041-2070
 Nimba West,LBR,National Park,0,1,1,2,2041-2070

--- a/lib/data/parcc/high_priority_protected_areas.csv
+++ b/lib/data/parcc/high_priority_protected_areas.csv
@@ -4,7 +4,7 @@ Abeanou,CIV,Classified Forest,0,1,1,2,2011-2040
 Abouderessou,CIV,Classified Forest,1,1,1,3,2011-2040
 Adzope,CIV,Classified Forest,1,1,0,2,2011-2040
 Agbo,CIV,Classified Forest,1,1,1,3,2011-2040
-Ahirasu Blocks I & II,GHA,Forest Reserve,1,1,0,2,2011-2040
+Ahirasu (Blocks I & II),GHA,Forest Reserve,1,1,0,2,2011-2040
 Ahua,CIV,Classified Forest,1,1,1,3,2011-2040
 Akrobong,GHA,Forest Reserve,0,1,1,2,2011-2040
 Amou-Mono,TGO,Forest Reserve,1,1,1,3,2011-2040
@@ -18,20 +18,20 @@ Boli,CIV,Classified Forest,0,1,1,2,2011-2040
 Bong Mountain,LBR,National Park,1,0,1,2,2011-2040
 Bongouanou,CIV,Classified Forest,1,1,1,3,2011-2040
 Bonsa Ben,GHA,Forest Reserve,1,1,0,2,2011-2040
-Classified Forest Name Unknown CIV No22,CIV,Classified Forest,0,1,1,2,2011-2040
-Classified Forest Name Unknown CIV No30,CIV,Classified Forest,1,0,1,2,2011-2040
-Classified Forest Name Unknown CIV No31,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No36,CIV,Classified Forest,0,1,1,2,2011-2040
-Classified Forest Name Unknown CIV No45,CIV,Classified Forest,1,0,1,2,2011-2040
-Classified Forest Name Unknown CIV No46,CIV,Classified Forest,1,1,0,2,2011-2040
-Classified Forest Name Unknown CIV No49,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No50,CIV,Classified Forest,1,1,0,2,2011-2040
-Classified Forest Name Unknown CIV No51,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No55,CIV,Classified Forest,0,1,1,2,2011-2040
-Classified Forest Name Unknown CIV No56,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No57,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No64,CIV,Classified Forest,1,1,1,3,2011-2040
-Classified Forest Name Unknown CIV No72,CIV,Classified Forest,1,1,0,2,2011-2040
+Classified Forest Name Unknown (CIV) No.22,CIV,Classified Forest,0,1,1,2,2011-2040
+Classified Forest Name Unknown (CIV) No.30,CIV,Classified Forest,1,0,1,2,2011-2040
+Classified Forest Name Unknown (CIV) No.31,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.36,CIV,Classified Forest,0,1,1,2,2011-2040
+Classified Forest Name Unknown (CIV) No.45,CIV,Classified Forest,1,0,1,2,2011-2040
+Classified Forest Name Unknown (CIV) No.46,CIV,Classified Forest,1,1,0,2,2011-2040
+Classified Forest Name Unknown (CIV) No.49,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.50,CIV,Classified Forest,1,1,0,2,2011-2040
+Classified Forest Name Unknown (CIV) No.51,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.55,CIV,Classified Forest,0,1,1,2,2011-2040
+Classified Forest Name Unknown (CIV) No.56,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.57,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.64,CIV,Classified Forest,1,1,1,3,2011-2040
+Classified Forest Name Unknown (CIV) No.72,CIV,Classified Forest,1,1,0,2,2011-2040
 Dan,BEN,Classified Forest,1,1,0,2,2011-2040
 De,CIV,Classified Forest,1,1,1,3,2011-2040
 Disue River,GHA,Forest Reserve,1,1,0,2,2011-2040
@@ -42,7 +42,7 @@ Fada Archei,TCD,Faunal Reserve,0,1,1,2,2011-2040
 Gboi Hills,SLE,Forest Reserve,1,1,0,2,2011-2040
 Gorke,CIV,Classified Forest,1,1,0,2,2011-2040
 Goudi,CIV,Classified Forest,1,0,1,2,2011-2040
-Inekar,MLI,Hunting Area,0,1,1,2,2011-2040
+Zone d'Intérêt Cynégétique d'Inekar,MLI,Hunting Area,0,1,1,2,2011-2040
 Jeni River,GHA,Forest Reserve,1,1,0,2,2011-2040
 Kambui Hills and Extensions,SLE,Forest Reserve,1,0,1,2,2011-2040
 Kassa,CIV,Classified Forest,1,1,0,2,2011-2040
@@ -73,7 +73,7 @@ Seguie,CIV,Classified Forest,1,1,0,2,2011-2040
 Taabo,CIV,Classified Forest,1,1,0,2,2011-2040
 Tchilla-Monota,TGO,Forest Reserve,1,1,0,2,2011-2040
 Tete,CIV,Classified Forest,0,1,1,2,2011-2040
-Tin Achara,MLI,Hunting Area,0,1,1,2,2011-2040
+Zone d'Intérêt Cynégétique de Tin Achara,MLI,Hunting Area,0,1,1,2,2011-2040
 Tiwai Island Sanctuary,SLE,Game Sanctuary / Non-hunting Forest Reserve,1,1,1,3,2011-2040
 Ukpam,NGA,Forest Reserve,1,0,1,2,2011-2040
 Vavoua,CIV,Classified Forest,0,1,1,2,2011-2040
@@ -81,13 +81,13 @@ Yandev,NGA,Forest Reserve,0,1,1,2,2011-2040
 Yoyo River,GHA,Forest Reserve,1,1,0,2,2011-2040
 Abasumba,GHA,Forest Reserve,1,1,1,3,2041-2070
 Abouderessou,CIV,Classified Forest,1,0,1,2,2041-2070
-Ahirasu Blocks I & II,GHA,Forest Reserve,1,1,0,2,2041-2070
+Ahirasu (Blocks I & II),GHA,Forest Reserve,1,1,0,2,2041-2070
 Ahua,CIV,Classified Forest,1,0,1,2,2041-2070
 Akrobong,GHA,Forest Reserve,1,1,0,2,2041-2070
 Banie,GIN,Classified Forest,1,1,0,2,2041-2070
-Classified Forest Name Unknown CIV No63,CIV,Classified Forest,1,1,0,2,2041-2070
-Classified Forest Name Unknown CIV No64,CIV,Classified Forest,1,1,1,3,2041-2070
-Classified Forest Name Unknown CIV No67,CIV,Classified Forest,0,1,1,2,2041-2070
+Classified Forest Name Unknown (CIV) No.63,CIV,Classified Forest,1,1,0,2,2041-2070
+Classified Forest Name Unknown (CIV) No.64,CIV,Classified Forest,1,1,1,3,2041-2070
+Classified Forest Name Unknown (CIV) No.67,CIV,Classified Forest,0,1,1,2,2041-2070
 Dechidan Stream,GHA,Forest Reserve,1,1,1,3,2041-2070
 Kalakpa,GHA,Game Production Reserve,1,1,0,2,2041-2070
 Kassa,CIV,Classified Forest,0,1,1,2,2041-2070
@@ -95,7 +95,7 @@ Kavi,CIV,Classified Forest,0,1,1,2,2041-2070
 Lakes of Ounianga,TCD,World Heritage Site,1,1,1,3,2041-2070
 Monogaga,CIV,Classified Forest,1,1,1,3,2041-2070
 Mount Nimba,CIV,National Reserve,1,1,1,3,2041-2070
-Mt De,CIV,Classified Forest,1,1,1,3,2041-2070
+Mt. De,CIV,Classified Forest,1,1,1,3,2041-2070
 Ndokouassikro,CIV,Classified Forest,1,0,1,2,2041-2070
 Nimba West,LBR,National Park,0,1,1,2,2041-2070
 Niouniourou,CIV,Classified Forest,0,1,1,2,2041-2070
@@ -107,7 +107,7 @@ Wologizi,LBR,National Park,1,1,0,2,2041-2070
 Yoyo River,GHA,Forest Reserve,1,1,0,2,2041-2070
 Zakpaberi,CIV,Classified Forest,1,0,1,2,2041-2070
 Banie,GIN,Classified Forest,1,1,1,3,2071-2100
-Classified Forest Name Unknown CIV No72,CIV,Classified Forest,1,1,0,2,2071-2100
+Classified Forest Name Unknown (CIV) No.72,CIV,Classified Forest,1,1,0,2,2071-2100
 Dam Makama,NGA,Forest Reserve,1,1,0,2,2071-2100
 Kavi,CIV,Classified Forest,1,1,0,2,2071-2100
 Kpo Mountains,LBR,National Park,1,1,0,2,2071-2100

--- a/lib/modules/parcc/importers/base.rb
+++ b/lib/modules/parcc/importers/base.rb
@@ -8,11 +8,9 @@ class Parcc::Importers::Base
 
   private
 
-  def csv_reader
-    @csv_reader ||= CSV.foreach(source_file_path, headers: true, header_converters: :symbol)
+  def csv_reader file_path
+    CSV.foreach(file_path, headers: true, header_converters: :symbol)
   end
-
-  private
 
   def source_file_path
     raise NotImplementedError, 'Define a source file for the specific importer'

--- a/lib/modules/parcc/importers/high_priority_protected_areas.rb
+++ b/lib/modules/parcc/importers/high_priority_protected_areas.rb
@@ -6,25 +6,16 @@ class Parcc::Importers::HighPriorityProtectedAreas < Parcc::Importers::Base
   end
 
   def import
-    populate_values source_file_path
-  end
-
-  def populate_values file_path
-    read_csv(file_path).each do |record|
+    csv_reader(source_file_path).each do |record|
       update_area(record)
     end
   end
 
+  private
+
   def update_area record
-    Parcc::ProtectedArea.find_by({name: name(record)}).try(:update, high_priority: true)
-  end
-
-  def name record
-    record.to_hash[:name]
-  end
-
-  def read_csv file_path
-    CSV.read(file_path, headers: true, header_converters: :symbol)
+    Parcc::ProtectedArea.find_by(name: record[:name],
+      designation: record[:designation]).try(:update, high_priority: true)
   end
 
   def source_file_path

--- a/lib/modules/parcc/importers/high_priority_protected_areas.rb
+++ b/lib/modules/parcc/importers/high_priority_protected_areas.rb
@@ -1,0 +1,34 @@
+class Parcc::Importers::HighPriorityProtectedAreas < Parcc::Importers::Base
+
+  def self.import
+    instance = new
+    instance.import
+  end
+
+  def import
+    populate_values source_file_path
+  end
+
+  def populate_values file_path
+    read_csv(file_path).each do |record|
+      update_area(record)
+    end
+  end
+
+  def update_area record
+    Parcc::ProtectedArea.find_by({name: name(record)}).try(:update, high_priority: true)
+  end
+
+  def name record
+    record.to_hash[:name]
+  end
+
+  def read_csv file_path
+    CSV.read(file_path, headers: true, header_converters: :symbol)
+  end
+
+  def source_file_path
+    Rails.root.join('lib/data/parcc/high_priority_protected_areas.csv')
+  end
+
+end

--- a/lib/modules/parcc/importers/protected_areas.rb
+++ b/lib/modules/parcc/importers/protected_areas.rb
@@ -19,7 +19,7 @@ class Parcc::Importers::ProtectedAreas < Parcc::Importers::Base
   end
 
   def import
-    csv_reader.each do |record|
+    csv_reader(source_file_path).each do |record|
       next unless properties = merge_properties(
         api: props_from_pp(record[:wdpaid]),
         csv: record

--- a/lib/modules/parcc/importers/species/counts.rb
+++ b/lib/modules/parcc/importers/species/counts.rb
@@ -1,6 +1,6 @@
 class Parcc::Importers::Species::Counts < Parcc::Importers::Base
   def import
-    csv_reader.each do |record|
+    csv_reader(source_file_path).each do |record|
       protected_area = fetch_protected_area(record[:wdpa_id])
       next unless protected_area
 

--- a/lib/modules/parcc/importers/species/taxonomies.rb
+++ b/lib/modules/parcc/importers/species/taxonomies.rb
@@ -6,7 +6,7 @@ class Parcc::Importers::Species::Taxonomies < Parcc::Importers::Base
   end
 
   def import
-    csv_reader.each do |record|
+    csv_reader(source_file_path).each do |record|
       next unless protected_area = fetch_protected_area(record[:wdpa_id])
       taxon_class = taxon_class(record[:species_taxon])
       taxon_order = taxon_order(record[:species_order], taxon_class)

--- a/lib/modules/parcc/importers/turnover.rb
+++ b/lib/modules/parcc/importers/turnover.rb
@@ -1,6 +1,4 @@
-require 'csv'
-
-class Parcc::Importers::Turnover
+class Parcc::Importers::Turnover < Parcc::Importers::Base
   extend Memoist
   STATS = [:median, :upper, :lower]
   COLUMN_FOR_PARCC_ID = :'' # yes, as odd as it looks
@@ -21,7 +19,7 @@ class Parcc::Importers::Turnover
       year: split_filename[3]
     }
 
-    read_csv(file_path).each do |record|
+    csv_reader(file_path).each do |record|
       create_record(turnover_defaults, record)
     end
   end
@@ -31,10 +29,6 @@ class Parcc::Importers::Turnover
     pa_id = {parcc_protected_area_id: pa_id_from_parcc_id(record[COLUMN_FOR_PARCC_ID])}
 
     Parcc::SpeciesTurnover.create defaults.merge(stats).merge(pa_id)
-  end
-
-  def read_csv file_path
-    CSV.foreach(file_path, headers: true, header_converters: :symbol)
   end
 
   memoize def files

--- a/test/unit/parcc/importers/high_priority_protected_areas_test.rb
+++ b/test/unit/parcc/importers/high_priority_protected_areas_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'csv'
+
+class TestParccImportersHighPriorityProtectedAreas < ActiveSupport::TestCase
+  test '#import sets high_priority to true to protected areas in the list' do
+    pa1 = FactoryGirl.create(
+      :parcc_protected_area,
+      {name: 'Abdoulaye', designation: 'National Reserve'}
+    )
+
+    CSV.expects(:foreach).returns([
+        {name: 'Abdoulaye', designation: 'National Reserve'}
+    ])
+
+    importer = Parcc::Importers::HighPriorityProtectedAreas.new
+    importer.import
+
+    assert_equal true, pa1.reload.high_priority
+  end
+end


### PR DESCRIPTION
This branch is about implementing an importer to add a flag for high priority protected areas.
- Changed csv to match PAs name and designation in the database
- Added high_priority boolean to Parcc::ProtectedArea model
- Added importer
- Some modifications to other importers